### PR TITLE
Add AI service skeleton and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,16 @@
 
 ## Table of Contents
 
-1. [Introduction](#introduction)  
-2. [Features](#features)  
-3. [Tech Stack](#tech-stack)  
-4. [Installation](#installation)  
-5. [Usage](#usage)  
-6. [UI Preview](#ui-preview)  
-7. [Roadmap](#roadmap)  
-8. [Contributing](#contributing)  
-9. [License](#license)  
+1. [Introduction](#introduction)
+2. [Features](#features)
+3. [Tech Stack](#tech-stack)
+4. [Repository Structure](#repository-structure)
+5. [Installation](#installation)
+6. [Usage](#usage)
+7. [UI Preview](#ui-preview)
+8. [Roadmap](#roadmap)
+9. [Contributing](#contributing)
+10. [License](#license)
 
 ---
 
@@ -60,6 +61,16 @@ In a world where moments pass in the blink of an eye, MemoirBox offers a secure,
 
 ---
 
+## Repository Structure
+
+The project is organized into separate services:
+
+- **frontend** – React interface built with Vite.
+- **backend** – Express API for core application logic.
+- **ai-service** – placeholder for machine learning features.
+
+---
+
 ## Installation
 
 ```bash
@@ -67,7 +78,7 @@ git clone git@github.com:2020331026-Anindya/MemoirBox.git
 cd MemoirBox
 npm install           # or yarn install
 cp .env.example .env  # set environment variables
-npm run dev           # spin up frontend + backend
+npm run dev           # spin up frontend, backend and AI service
 ```
 
 ---

--- a/ai-service/README.md
+++ b/ai-service/README.md
@@ -1,0 +1,3 @@
+# AI Service
+
+This service implements machine learning features for MemoirBox. It exposes a simple Express API as a placeholder for tasks like face recognition or image processing.

--- a/ai-service/package.json
+++ b/ai-service/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "memoirbox-ai-service",
+  "version": "1.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "ts-node src/index.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "ts-node": "^10.0.0",
+    "@types/node": "^18.0.0",
+    "@types/express": "^4.17.13"
+  }
+}

--- a/ai-service/src/index.ts
+++ b/ai-service/src/index.ts
@@ -1,0 +1,12 @@
+import express from 'express';
+
+const app = express();
+const port = process.env.PORT || 4000;
+
+app.get('/', (_req, res) => {
+  res.send('MemoirBox AI Service');
+});
+
+app.listen(port, () => {
+  console.log(`AI service listening on port ${port}`);
+});

--- a/ai-service/tsconfig.json
+++ b/ai-service/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,3 @@
+# Backend
+
+The backend service provides the main REST API for MemoirBox. It is built with Express and contains authentication and data endpoints for the application.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,3 @@
+# Frontend
+
+This React application delivers the user interface for MemoirBox. It is built with Vite and communicates with the backend services.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,24 @@
       "version": "0.1.0",
       "workspaces": [
         "frontend",
-        "backend"
+        "backend",
+        "ai-service"
       ],
       "devDependencies": {
         "concurrently": "^8.0.1"
+      }
+    },
+    "ai-service": {
+      "name": "memoirbox-ai-service",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.18.2"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.13",
+        "@types/node": "^18.0.0",
+        "ts-node": "^10.0.0",
+        "typescript": "^5.0.0"
       }
     },
     "backend": {
@@ -1974,6 +1988,10 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/memoirbox-ai-service": {
+      "resolved": "ai-service",
+      "link": true
     },
     "node_modules/memoirbox-backend": {
       "resolved": "backend",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "memoirbox",
   "version": "0.1.0",
   "private": true,
-  "workspaces": ["frontend", "backend"],
+  "workspaces": ["frontend", "backend", "ai-service"],
   "scripts": {
-    "dev": "concurrently \"npm run dev --prefix frontend\" \"npm run dev --prefix backend\""
+    "dev": "concurrently \"npm run dev --prefix frontend\" \"npm run dev --prefix backend\" \"npm run dev --prefix ai-service\""
   },
   "devDependencies": {
     "concurrently": "^8.0.1"


### PR DESCRIPTION
## Summary
- create `ai-service` with TypeScript setup
- document each service with folder-level README files
- describe repo structure in main README
- update dev script and workspaces for new service

## Testing
- `npm install`
- `npm --workspace backend run build`
- `npm --workspace ai-service run build`
- `npm --workspace frontend run build`


------
https://chatgpt.com/codex/tasks/task_b_684dc274e70c832baf0ab0c1447e70bf